### PR TITLE
Add interactive sub-band visualizer with dynamic labels and animations

### DIFF
--- a/src/components/SpectrumView.js
+++ b/src/components/SpectrumView.js
@@ -574,42 +574,43 @@ const SpectrumView = () => {
                   const laneSpacing = 12;
                   const externalLabelThreshold = 40;
 
-                  selectedBand.subbands.forEach((sb) => {
+                  selectedBand.subbands.forEach((sb, i) => {
                     const xStart = scale(sb.start);
                     const xEnd = scale(sb.end);
                     const barWidth = xEnd - xStart;
                     const fill = getModeColor(sb.mode);
                     const centerX = (xStart + xEnd) / 2;
-                    const label = sb.label.length > 30 ? sb.label.slice(0, 27) + '…' : sb.label;
-
-                    // Draw the main subband bar
-                    svg.append("rect")
-                      .attr("x", xStart)
+                    const label = sb.label.length > 20 ? sb.label.slice(0, 17) + '…' : sb.label;
+                  
+                    // Subband bar with animation
+                    svg.selectAll(`.subband-bar-${i}`)
+                      .data([sb])
+                      .join("rect")
+                      .attr("class", `subband-bar-${i}`)
                       .attr("y", 20)
-                      .attr("width", barWidth)
                       .attr("height", 12)
-                      .attr("fill", fill);
-
-                      console.log({
-                        label: sb.label,
-                        barWidth,
-                        centerX,
-                        start: sb.start,
-                        end: sb.end
-                      });                      
-
+                      .attr("fill", fill)
+                      .attr("x", xStart)
+                      .attr("width", 0)
+                      .transition()
+                      .duration(400)
+                      .attr("width", barWidth);
+                  
                     if (barWidth >= externalLabelThreshold) {
-                      // Inline label for wide enough bands
+                      // Inline label with fade-in
                       svg.append("text")
                         .attr("x", centerX)
                         .attr("y", 30)
                         .attr("text-anchor", "middle")
                         .attr("fill", "#fff")
                         .attr("font-size", "10px")
-                        .text(label);
+                        .style("opacity", 0)
+                        .text(label)
+                        .transition()
+                        .duration(300)
+                        .style("opacity", 1);
                     } else {
-                      // === External Label Placement ===
-                      // Find a lane with no conflicts
+                      // External label placement
                       let lane = 0;
                       while (
                         labelLanes[lane]?.some(pos => Math.abs(pos - centerX) < 50)
@@ -618,28 +619,35 @@ const SpectrumView = () => {
                       }
                       if (!labelLanes[lane]) labelLanes[lane] = [];
                       labelLanes[lane].push(centerX);
-
+                  
                       const labelY = 10 - lane * laneSpacing;
-
-                      // Draw external label above the bar
+                  
+                      // Fade-in external label
                       svg.append("text")
                         .attr("x", centerX)
                         .attr("y", labelY)
                         .attr("text-anchor", "middle")
                         .attr("fill", "#ccc")
                         .attr("font-size", "9px")
-                        .text(label);
-
-                      // Draw connector line from label to band
+                        .style("opacity", 0)
+                        .text(label)
+                        .transition()
+                        .duration(300)
+                        .style("opacity", 1);
+                  
+                      // Animate connector line growing downward
                       svg.append("line")
                         .attr("x1", centerX)
                         .attr("x2", centerX)
                         .attr("y1", labelY + 2)
-                        .attr("y2", 20)
+                        .attr("y2", labelY + 2)
                         .attr("stroke", "#999")
-                        .attr("stroke-width", 1);
+                        .attr("stroke-width", 1)
+                        .transition()
+                        .duration(400)
+                        .attr("y2", 20);
                     }
-                  });
+                  });                                    
                 }}
                 style={{ width: '100%', height: '70px', marginTop: '10px' }}
               />

--- a/src/components/SpectrumView.js
+++ b/src/components/SpectrumView.js
@@ -519,79 +519,87 @@ const SpectrumView = () => {
   
           {selectedBand.subbands && (
             <>
-              {/* Visual Subband Spectrum */}
-              <div style={{ width: '100%', overflowX: 'auto' }}>
-                <svg
-                  ref={(el) => {
-                    if (!el || !selectedBand) return;
+              {/* Visual Subband Spectrum with Labels and Responsive Height */}
+              <svg
+                ref={(el) => {
+                  if (!el || !selectedBand) return;
+                  const svg = d3.select(el);
+                  svg.selectAll("*").remove();
 
-                    const containerWidth = el.clientWidth;
-                    const svg = d3.select(el);
-                    svg.selectAll('*').remove();
+                  const width = el.getBoundingClientRect().width;
+                  const height = 70;
+                  svg.attr("width", width).attr("height", height);
 
-                    const modeColors = {
-                      'rtty': '#bf616a',
-                      'phone': '#a3be8c',
-                      'image': '#a3be8c',
-                      'cw': '#888888',
-                      'ssb phone only': '#ebcb8b',
-                      'usb phone cw rtty and data': '#5e81ac',
-                      'fixed digital forwarding systems only': '#d08770',
-                      'digital': '#bf616a',
-                      'ssb': '#ebcb8b'
-                    };
+                  const modeColors = {
+                    'rtty': '#bf616a',
+                    'phone': '#a3be8c',
+                    'image': '#a3be8c',
+                    'cw': '#888888',
+                    'ssb phone only': '#ebcb8b',
+                    'usb phone cw rtty and data': '#5e81ac',
+                    'fixed digital forwarding systems only': '#d08770',
+                    'digital': '#bf616a',
+                    'ssb': '#ebcb8b'
+                  };
 
-                    const barY = 15;
-                    const barHeight = 10;
-                    const labelY = 48;
+                  const scale = d3.scaleLinear()
+                    .domain([selectedBand.start, selectedBand.end])
+                    .range([0, width]);
 
-                    const scale = d3.scaleLinear()
-                      .domain([selectedBand.start, selectedBand.end])
-                      .range([0, containerWidth]);
+                  // Background bar
+                  svg.append("rect")
+                    .attr("x", 0)
+                    .attr("y", 20)
+                    .attr("width", width)
+                    .attr("height", 12)
+                    .attr("fill", "#333");
 
-                    // Draw base band bar
-                    svg.append('rect')
-                      .attr('x', 0)
-                      .attr('y', barY)
-                      .attr('width', containerWidth)
-                      .attr('height', barHeight)
-                      .attr('fill', '#333');
+                  // Subband colored bars and labels
+                  selectedBand.subbands.forEach((sb) => {
+                    const xStart = scale(sb.start);
+                    const xEnd = scale(sb.end);
+                    const barWidth = xEnd - xStart;
+                    const fill = modeColors[(sb.mode || '').trim().toLowerCase()] || '#88c0d0';
 
-                    // Draw subbands
-                    selectedBand.subbands.forEach(sb => {
-                      svg.append('rect')
-                        .attr('x', scale(sb.start))
-                        .attr('y', barY)
-                        .attr('width', scale(sb.end) - scale(sb.start))
-                        .attr('height', barHeight)
-                        .attr('fill', modeColors[(sb.mode || '').trim().toLowerCase()] || '#88c0d0');
-                    });
+                    svg.append("rect")
+                      .attr("x", xStart)
+                      .attr("y", 20)
+                      .attr("width", barWidth)
+                      .attr("height", 12)
+                      .attr("fill", fill);
 
-                    // Draw tick marks and labels
-                    const ticks = d3.ticks(selectedBand.start, selectedBand.end, 6);
-                    ticks.forEach(freq => {
-                      const x = scale(freq);
-                      svg.append('line')
-                        .attr('x1', x)
-                        .attr('x2', x)
-                        .attr('y1', barY + barHeight)
-                        .attr('y2', barY + barHeight + 6)
-                        .attr('stroke', '#aaa')
-                        .attr('stroke-width', 1);
-                      svg.append('text')
-                        .attr('x', x)
-                        .attr('y', labelY)
-                        .attr('text-anchor', 'middle')
-                        .attr('font-size', '10px')
-                        .attr('fill', '#ccc')
-                        .text(`${(freq / 1e6).toFixed(3)} MHz`);
-                    });
-                  }}
-                  width="100%"
-                  height="60"
-                  style={{ marginTop: '10px' }}
-                />
-              </div>
+                    if (barWidth > 30) {
+                      svg.append("text")
+                        .attr("x", xStart + barWidth / 2)
+                        .attr("y", 30)
+                        .attr("text-anchor", "middle")
+                        .attr("fill", "#fff")
+                        .attr("font-size", "10px")
+                        .text(sb.label.length > 20 ? sb.label.slice(0, 17) + '…' : sb.label);
+                    }
+                  });
+
+                  // Frequency ticks
+                  d3.ticks(selectedBand.start, selectedBand.end, 5).forEach((freq) => {
+                    const x = scale(freq);
+                    svg.append("line")
+                      .attr("x1", x)
+                      .attr("x2", x)
+                      .attr("y1", 32)
+                      .attr("y2", 42)
+                      .attr("stroke", "#aaa");
+
+                    svg.append("text")
+                      .attr("x", x)
+                      .attr("y", 55)
+                      .attr("text-anchor", "middle")
+                      .attr("fill", "#ccc")
+                      .attr("font-size", "10px")
+                      .text((freq / 1e6).toFixed(3) + " MHz");
+                  });
+                }}
+                style={{ width: '100%', height: '70px', marginTop: '10px' }}
+              />
   
               {/* Legend */}
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', marginTop: '0.5rem' }}>

--- a/src/components/SpectrumView.js
+++ b/src/components/SpectrumView.js
@@ -36,6 +36,141 @@ function truncateToFit(textElem, fullLabel, maxWidthPx) {
   }
 }
 
+function renderSubbands(svg, bandData, scale, options = {}) {
+  const {
+    barHeight = 12,
+    animate = true,
+    externalLabelThreshold = 40,
+    transitionDuration = 400,
+  } = options;
+
+  const baseModeColors = {
+    cw: '#888888',
+    ssb: '#ebcb8b',
+    fm: '#a3be8c',
+    digital: '#bf616a',
+    atv: '#b48ead',
+    satellite: '#5e81ac',
+    experimental: '#d08770',
+    mixed: '#88c0d0',
+  };
+
+  const getModeColor = (mode) => {
+    if (!mode) return '#555';
+    const cleaned = mode.trim().toLowerCase();
+    if (baseModeColors[cleaned]) return baseModeColors[cleaned];
+    const parts = cleaned.split(/[/\s]+/);
+    for (const part of parts) {
+      if (baseModeColors[part]) return baseModeColors[part];
+    }
+    return '#999';
+  };
+
+  svg.selectAll("*").remove();
+
+  const width = parseFloat(svg.attr("width")) || 800;
+  svg.append("rect")
+    .attr("x", 0)
+    .attr("y", 20)
+    .attr("width", width)
+    .attr("height", barHeight)
+    .attr("fill", "#333");
+
+  const labelLanes = [];
+  const laneSpacing = 12;
+
+  bandData.subbands.forEach((sb, i) => {
+    const xStart = scale(sb.start);
+    const xEnd = scale(sb.end);
+    const barWidth = xEnd - xStart;
+    const centerX = xStart + barWidth / 2;
+    const fill = getModeColor(sb.mode);
+    const label = sb.label.length > 20 ? sb.label.slice(0, 17) + '…' : sb.label;
+
+    const bar = svg.append("rect")
+      .attr("x", xStart)
+      .attr("y", 20)
+      .attr("width", 0)
+      .attr("height", barHeight)
+      .attr("fill", fill);
+
+    if (animate) {
+      bar.transition()
+        .duration(transitionDuration)
+        .attr("width", barWidth);
+    } else {
+      bar.attr("width", barWidth);
+    }
+
+    if (barWidth >= externalLabelThreshold) {
+      svg.append("text")
+        .attr("x", centerX)
+        .attr("y", 30)
+        .attr("text-anchor", "middle")
+        .attr("fill", "#fff")
+        .attr("font-size", "10px")
+        .text(label)
+        .style("opacity", 0)
+        .transition()
+        .duration(transitionDuration)
+        .style("opacity", 1);
+    } else {
+      let lane = 0;
+      while (
+        labelLanes[lane]?.some(pos => Math.abs(pos - centerX) < 50)
+      ) {
+        lane++;
+      }
+      if (!labelLanes[lane]) labelLanes[lane] = [];
+      labelLanes[lane].push(centerX);
+
+      const labelY = 10 - lane * laneSpacing;
+
+      svg.append("text")
+        .attr("x", centerX)
+        .attr("y", labelY)
+        .attr("text-anchor", "middle")
+        .attr("fill", "#ccc")
+        .attr("font-size", "9px")
+        .text(label)
+        .style("opacity", 0)
+        .transition()
+        .duration(transitionDuration)
+        .style("opacity", 1);
+
+      svg.append("line")
+        .attr("x1", centerX)
+        .attr("x2", centerX)
+        .attr("y1", labelY + 2)
+        .attr("y2", 20)
+        .attr("stroke", "#999")
+        .attr("stroke-width", 1)
+        .style("opacity", 0)
+        .transition()
+        .duration(transitionDuration)
+        .style("opacity", 1);
+    }
+  });
+
+  d3.ticks(bandData.start, bandData.end, 5).forEach((freq) => {
+    const x = scale(freq);
+    svg.append("line")
+      .attr("x1", x)
+      .attr("x2", x)
+      .attr("y1", 32)
+      .attr("y2", 42)
+      .attr("stroke", "#aaa");
+
+    svg.append("text")
+      .attr("x", x)
+      .attr("y", 55)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#ccc")
+      .attr("font-size", "10px")
+      .text((freq / 1e6).toFixed(3) + " MHz");
+  });
+}
+
 const SpectrumView = () => {
   const ref = useRef();
   const zoomRef = useRef();
@@ -574,79 +709,11 @@ const SpectrumView = () => {
                   const laneSpacing = 12;
                   const externalLabelThreshold = 40;
 
-                  selectedBand.subbands.forEach((sb, i) => {
-                    const xStart = scale(sb.start);
-                    const xEnd = scale(sb.end);
-                    const barWidth = xEnd - xStart;
-                    const fill = getModeColor(sb.mode);
-                    const centerX = (xStart + xEnd) / 2;
-                    const label = sb.label.length > 20 ? sb.label.slice(0, 17) + '…' : sb.label;
-                  
-                    // Subband bar with animation
-                    svg.selectAll(`.subband-bar-${i}`)
-                      .data([sb])
-                      .join("rect")
-                      .attr("class", `subband-bar-${i}`)
-                      .attr("y", 20)
-                      .attr("height", 12)
-                      .attr("fill", fill)
-                      .attr("x", xStart)
-                      .attr("width", 0)
-                      .transition()
-                      .duration(400)
-                      .attr("width", barWidth);
-                  
-                    if (barWidth >= externalLabelThreshold) {
-                      // Inline label with fade-in
-                      svg.append("text")
-                        .attr("x", centerX)
-                        .attr("y", 30)
-                        .attr("text-anchor", "middle")
-                        .attr("fill", "#fff")
-                        .attr("font-size", "10px")
-                        .style("opacity", 0)
-                        .text(label)
-                        .transition()
-                        .duration(300)
-                        .style("opacity", 1);
-                    } else {
-                      // External label placement
-                      let lane = 0;
-                      while (
-                        labelLanes[lane]?.some(pos => Math.abs(pos - centerX) < 50)
-                      ) {
-                        lane++;
-                      }
-                      if (!labelLanes[lane]) labelLanes[lane] = [];
-                      labelLanes[lane].push(centerX);
-                  
-                      const labelY = 10 - lane * laneSpacing;
-                  
-                      // Fade-in external label
-                      svg.append("text")
-                        .attr("x", centerX)
-                        .attr("y", labelY)
-                        .attr("text-anchor", "middle")
-                        .attr("fill", "#ccc")
-                        .attr("font-size", "9px")
-                        .style("opacity", 0)
-                        .text(label)
-                        .transition()
-                        .duration(300)
-                        .style("opacity", 1);
-                  
-                      // Animate connector line growing downward
-                      svg.append("line")
-                        .attr("x1", centerX)
-                        .attr("x2", centerX)
-                        .attr("y1", labelY + 2)
-                        .attr("y2", labelY + 2)
-                        .attr("stroke", "#999")
-                        .attr("stroke-width", 1)
-                        .transition()
-                        .duration(400)
-                        .attr("y2", 20);
-                    }
+                  renderSubbands(svg, selectedBand, scale, {
+                    animate: true,
+                    barHeight: 12,
+                    externalLabelThreshold: 40,
+                    transitionDuration: 500,
                   });                                    
                 }}
                 style={{ width: '100%', height: '70px', marginTop: '10px' }}

--- a/src/components/SpectrumView.js
+++ b/src/components/SpectrumView.js
@@ -520,43 +520,87 @@ const SpectrumView = () => {
           {selectedBand.subbands && (
             <>
               {/* Visual Subband Spectrum */}
-              <svg width="100%" height="40" style={{ marginTop: '10px' }}>
-                <rect x={0} y={15} width="100%" height={10} fill="#333" />
-                {(() => {
-                  const totalWidth = 1000;
-                  const modeColors = {
-                    RTTY: '#bf616a',
-                    Phone: '#a3be8c',
-                    Image: '#a3be8c',
-                    CW: '#888888',
-                    'SSB phone only': '#ebcb8b',
-                    'USB phone CW RTTY and data': '#5e81ac',
-                    'Fixed digital forwarding systems only': '#d08770',
-                  };
-                  const scale = d3.scaleLinear()
-                    .domain([selectedBand.start, selectedBand.end])
-                    .range([0, totalWidth]);
-                  return selectedBand.subbands.map((sb, i) => (
-                    <rect
-                      key={i}
-                      x={scale(sb.start)}
-                      y={15}
-                      width={scale(sb.end) - scale(sb.start)}
-                      height={10}
-                      fill={modeColors[sb.mode] || '#88c0d0'}
-                    />
-                  ));
-                })()}
-              </svg>
+              <div style={{ width: '100%', overflowX: 'auto' }}>
+                <svg
+                  ref={(el) => {
+                    if (!el || !selectedBand) return;
+
+                    const containerWidth = el.clientWidth;
+                    const svg = d3.select(el);
+                    svg.selectAll('*').remove();
+
+                    const modeColors = {
+                      'rtty': '#bf616a',
+                      'phone': '#a3be8c',
+                      'image': '#a3be8c',
+                      'cw': '#888888',
+                      'ssb phone only': '#ebcb8b',
+                      'usb phone cw rtty and data': '#5e81ac',
+                      'fixed digital forwarding systems only': '#d08770',
+                      'digital': '#bf616a',
+                      'ssb': '#ebcb8b'
+                    };
+
+                    const barY = 15;
+                    const barHeight = 10;
+                    const labelY = 48;
+
+                    const scale = d3.scaleLinear()
+                      .domain([selectedBand.start, selectedBand.end])
+                      .range([0, containerWidth]);
+
+                    // Draw base band bar
+                    svg.append('rect')
+                      .attr('x', 0)
+                      .attr('y', barY)
+                      .attr('width', containerWidth)
+                      .attr('height', barHeight)
+                      .attr('fill', '#333');
+
+                    // Draw subbands
+                    selectedBand.subbands.forEach(sb => {
+                      svg.append('rect')
+                        .attr('x', scale(sb.start))
+                        .attr('y', barY)
+                        .attr('width', scale(sb.end) - scale(sb.start))
+                        .attr('height', barHeight)
+                        .attr('fill', modeColors[(sb.mode || '').trim().toLowerCase()] || '#88c0d0');
+                    });
+
+                    // Draw tick marks and labels
+                    const ticks = d3.ticks(selectedBand.start, selectedBand.end, 6);
+                    ticks.forEach(freq => {
+                      const x = scale(freq);
+                      svg.append('line')
+                        .attr('x1', x)
+                        .attr('x2', x)
+                        .attr('y1', barY + barHeight)
+                        .attr('y2', barY + barHeight + 6)
+                        .attr('stroke', '#aaa')
+                        .attr('stroke-width', 1);
+                      svg.append('text')
+                        .attr('x', x)
+                        .attr('y', labelY)
+                        .attr('text-anchor', 'middle')
+                        .attr('font-size', '10px')
+                        .attr('fill', '#ccc')
+                        .text(`${(freq / 1e6).toFixed(3)} MHz`);
+                    });
+                  }}
+                  width="100%"
+                  height="60"
+                  style={{ marginTop: '10px' }}
+                />
+              </div>
   
               {/* Legend */}
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', marginTop: '0.5rem' }}>
                 {[
-                  ['RTTY', '#bf616a'],
+                  ['RTTY/Data', '#bf616a'],
                   ['Phone / Image', '#a3be8c'],
                   ['CW', '#888888'],
                   ['SSB phone only', '#ebcb8b'],
-                  ['USB phone CW RTTY and data', '#5e81ac'],
+                  ['USB phone CW, RTTY and data', '#5e81ac'],
                   ['Fixed digital forwarding systems only', '#d08770'],
                 ].map(([label, color]) => (
                   <div key={label} style={{ display: 'flex', alignItems: 'center', fontSize: '0.9rem' }}>

--- a/src/data/subbands.json
+++ b/src/data/subbands.json
@@ -137,51 +137,88 @@
         "start": 1240000000,
         "end": 1300000000,
         "subbands": [
-          { "start": 1240000000, "end": 1246000000, "label": "Weak Signal", "mode": "SSB" },
-          { "start": 1246000000, "end": 1252000000, "label": "Repeater Outputs", "mode": "FM" },
-          { "start": 1260000000, "end": 1270000000, "label": "Repeater Inputs", "mode": "FM" },
-          { "start": 1296000000, "end": 1300000000, "label": "Experimental / DATV", "mode": "Digital" }
+          { "start": 1240000000, "end": 1246000000, "label": "Weak Signal / ATV #1", "mode": "SSB / ATV" },
+          { "start": 1246000000, "end": 1248000000, "label": "Narrow FMl", "mode": "FM/Digital" },
+          { "start": 1248000000, "end": 1258000000, "label": "Digital Communications", "mode": "Digital" },
+          { "start": 1258000000, "end": 1260000000, "label": "ATV #2", "mode": "ATV" },
+          { "start": 1260000000, "end": 1270000000, "label": "Satellite Uplinks", "mode": "Satellite" },
+          { "start": 1270000000, "end": 1276000000, "label": "Repeater Inputs", "mode": "FM/Linear" },
+          { "start": 1276000000, "end": 1282000000, "label": "ATV #3", "mode": "ATV" },
+          { "start": 1282000000, "end": 1288000000, "label": "Repeater Outputs", "mode": "FM/Linear" },
+          { "start": 1288000000, "end": 1294000000, "label": "Wide-band Experimental", "mode": "Experimental" },
+          { "start": 1294000000, "end": 1300000000, "label": "Digital Communications", "mode": "Digital" }
         ]
-      },
+      },      
       {
         "band": "13 cm Amateur Radio",
         "start": 2300000000,
         "end": 2450000000,
         "subbands": [
-          { "start": 2300000000, "end": 2310000000, "label": "Weak Signal", "mode": "SSB" },
+          { "start": 2300000000, "end": 2310000000, "label": "Narrow-band Modes / Weak Signal", "mode": "CW/SSB" },
           { "start": 2310000000, "end": 2330000000, "label": "Digital Modes / ATV", "mode": "Digital" },
-          { "start": 2390000000, "end": 2450000000, "label": "ISM / Shared Use", "mode": "Mixed" }
+          { "start": 2390000000, "end": 2450000000, "label": "ISM / Wide-band / Shared Use", "mode": "Mixed" }
         ]
-      },
+      },      
       {
         "band": "9 cm Amateur Radio",
         "start": 3300000000,
         "end": 3500000000,
         "subbands": [
-          { "start": 3300000000, "end": 3320000000, "label": "Weak Signal", "mode": "SSB" },
+          { "start": 3300000000, "end": 3320000000, "label": "Weak Signal / Narrow-band", "mode": "CW/SSB" },
           { "start": 3320000000, "end": 3400000000, "label": "ATV / Experimental", "mode": "Digital" },
-          { "start": 3456000000, "end": 3500000000, "label": "Beacon / Mixed", "mode": "Mixed" }
+          { "start": 3400000000, "end": 3410000000, "label": "Satellite Uplinks", "mode": "Satellite" },
+          { "start": 3410000000, "end": 3500000000, "label": "Wide-band / Beacon", "mode": "Mixed" }
         ]
-      },
+      },      
       {
         "band": "5 cm Amateur Radio",
         "start": 5650000000,
         "end": 5925000000,
         "subbands": [
           { "start": 5650000000, "end": 5668000000, "label": "Weak Signal", "mode": "SSB" },
-          { "start": 5668000000, "end": 5725000000, "label": "Telemetry / UAV", "mode": "Digital" },
+          { "start": 5668000000, "end": 5670000000, "label": "Satellite Uplinks", "mode": "Satellite" },
+          { "start": 5670000000, "end": 5725000000, "label": "Telemetry / UAV", "mode": "Digital" },
           { "start": 5725000000, "end": 5850000000, "label": "FPV Video", "mode": "Digital" },
-          { "start": 5850000000, "end": 5925000000, "label": "ISM / Mixed", "mode": "Mixed" }
+          { "start": 5850000000, "end": 5925000000, "label": "ISM / Wide-band / Mixed", "mode": "Mixed" }
         ]
-      },
+      },      
       {
         "band": "3 cm Amateur Radio",
         "start": 10000000000,
         "end": 10500000000,
         "subbands": [
-          { "start": 10000000000, "end": 10150000000, "label": "Weak Signal / Beacons", "mode": "SSB" },
+          { "start": 10000000000, "end": 10150000000, "label": "Weak Signal / Beacons / Narrow-band", "mode": "CW/SSB" },
           { "start": 10150000000, "end": 10300000000, "label": "Digital / Experimental", "mode": "Digital" },
-          { "start": 10300000000, "end": 10500000000, "label": "Mixed / UAV", "mode": "Mixed" }
+          { "start": 10300000000, "end": 10450000000, "label": "Mixed / UAV", "mode": "Mixed" },
+          { "start": 10450000000, "end": 10500000000, "label": "Satellite Downlinks", "mode": "Satellite" }
+        ]
+      },
+      {
+        "band": "1.25 cm Amateur Radio",
+        "start": 24000000000,
+        "end": 24250000000,
+        "subbands": [
+          { "start": 24000000000, "end": 24050000000, "label": "Satellite Uplinks", "mode": "Satellite" },
+          { "start": 24050000000, "end": 24250000000, "label": "Wide-band Modes", "mode": "FM/ATV/Digital" }
+        ]
+      },
+      {
+        "band": "6 mm Amateur Radio",
+        "start": 47000000000,
+        "end": 47200000000,
+        "subbands": [
+          { "start": 47000000000, "end": 47200000000, "label": "All Modes", "mode": "CW/SSB/FM/Digital" }
+        ]
+      },
+      {
+        "band": "4 mm Amateur Radio",
+        "start": 75500000000,
+        "end": 81000000000,
+        "subbands": [
+          { "start": 75500000000, "end": 76000000000, "label": "All Modes", "mode": "CW/SSB/FM/Digital" },
+          { "start": 76000000000, "end": 77500000000, "label": "All Modes", "mode": "CW/SSB/FM/Digital" },
+          { "start": 77500000000, "end": 78000000000, "label": "All Modes", "mode": "CW/SSB/FM/Digital" },
+          { "start": 78000000000, "end": 81000000000, "label": "All Modes", "mode": "CW/SSB/FM/Digital" }
         ]
       }
   ]

--- a/src/data/subbands.json
+++ b/src/data/subbands.json
@@ -1,5 +1,24 @@
 [
     {
+      "band": "160 m Amateur Radio",
+      "start": 1800000,
+      "end": 2000000,
+      "subbands": [
+        { "start": 1800000, "end": 1830000, "label": "CW", "mode": "CW" },
+        { "start": 1830000, "end": 1850000, "label": "Digital", "mode": "Digital" },
+        { "start": 1850000, "end": 2000000, "label": "Phone", "mode": "SSB" }
+      ]
+    },
+    {
+      "band": "30 m Amateur Radio",
+      "start": 10100000,
+      "end": 10150000,
+      "subbands": [
+        { "start": 10100000, "end": 10130000, "label": "CW", "mode": "CW" },
+        { "start": 10130000, "end": 10150000, "label": "Digital Only", "mode": "Digital" }
+      ]
+    },
+    {
       "band": "40 m Amateur Radio",
       "start": 7000000,
       "end": 7300000,
@@ -8,6 +27,67 @@
         { "start": 7030000, "end": 7040000, "label": "FT8", "mode": "Digital" },
         { "start": 7040000, "end": 7125000, "label": "Digital Modes", "mode": "Digital" },
         { "start": 7125000, "end": 7300000, "label": "Phone", "mode": "SSB" }
+      ]
+    },
+    {
+      "band": "60 m Amateur Radio",
+      "start": 5332000,
+      "end": 5405000,
+      "subbands": [
+        { "start": 5332000, "end": 5346000, "label": "Channel 1", "mode": "Digital" },
+        { "start": 5346000, "end": 5358000, "label": "Channel 2", "mode": "Digital" },
+        { "start": 5358000, "end": 5370000, "label": "Channel 3", "mode": "Digital" },
+        { "start": 5370000, "end": 5382000, "label": "Channel 4", "mode": "Digital" },
+        { "start": 5403000, "end": 5405000, "label": "Channel 5", "mode": "Digital" }
+      ]
+    },
+    {
+      "band": "80 m Amateur Radio",
+      "start": 3500000,
+      "end": 4000000,
+      "subbands": [
+        { "start": 3500000, "end": 3570000, "label": "CW", "mode": "CW" },
+        { "start": 3570000, "end": 3600000, "label": "Digital Modes", "mode": "Digital" },
+        { "start": 3600000, "end": 4000000, "label": "Phone", "mode": "SSB" }
+      ]
+    },
+    {
+      "band": "10 m Amateur Radio",
+      "start": 28000000,
+      "end": 29700000,
+      "subbands": [
+        { "start": 28000000, "end": 28070000, "label": "CW", "mode": "CW" },
+        { "start": 28074000, "end": 28074000, "label": "FT8", "mode": "Digital" },
+        { "start": 28070000, "end": 28300000, "label": "Digital Modes", "mode": "Digital" },
+        { "start": 28300000, "end": 29700000, "label": "Phone", "mode": "SSB" }
+      ]
+    },
+    {
+      "band": "12 m Amateur Radio",
+      "start": 24890000,
+      "end": 24990000,
+      "subbands": [
+        { "start": 24890000, "end": 24920000, "label": "CW", "mode": "CW" },
+        { "start": 24920000, "end": 24990000, "label": "Digital/SSB", "mode": "Digital" }
+      ]
+    },
+    {
+      "band": "15 m Amateur Radio",
+      "start": 21000000,
+      "end": 21450000,
+      "subbands": [
+        { "start": 21000000, "end": 21070000, "label": "CW", "mode": "CW" },
+        { "start": 21070000, "end": 21150000, "label": "Digital Modes", "mode": "Digital" },
+        { "start": 21150000, "end": 21450000, "label": "Phone", "mode": "SSB" }
+      ]
+    },
+    {
+      "band": "17 m Amateur Radio",
+      "start": 18068000,
+      "end": 18168000,
+      "subbands": [
+        { "start": 18068000, "end": 18110000, "label": "CW", "mode": "CW" },
+        { "start": 18110000, "end": 18168000, "label": "Digital/Data", "mode": "Digital" }
       ]
     },
     {
@@ -31,6 +111,78 @@
         { "start": 144500000, "end": 145800000, "label": "FM Repeater/Voice", "mode": "FM" },
         { "start": 145800000, "end": 146000000, "label": "Satellite Uplink", "mode": "Mixed" }
       ]
-    }
+    },
+    {
+      "band": "6 m Amateur Radio",
+      "start": 50000000,
+      "end": 54000000,
+      "subbands": [
+        { "start": 50000000, "end": 50100000, "label": "CW", "mode": "CW" },
+        { "start": 50100000, "end": 50200000, "label": "Digital Modes", "mode": "Digital" },
+        { "start": 50200000, "end": 54000000, "label": "Phone / FM", "mode": "FM" }
+      ]
+    },
+    {
+        "band": "1.25 m Amateur Radio",
+        "start": 222000000,
+        "end": 225000000,
+        "subbands": [
+          { "start": 222000000, "end": 222100000, "label": "CW", "mode": "CW" },
+          { "start": 222100000, "end": 222500000, "label": "Weak Signal", "mode": "SSB" },
+          { "start": 223000000, "end": 225000000, "label": "FM Repeater/Voice", "mode": "FM" }
+        ]
+      },
+      {
+        "band": "23 cm Amateur Radio",
+        "start": 1240000000,
+        "end": 1300000000,
+        "subbands": [
+          { "start": 1240000000, "end": 1246000000, "label": "Weak Signal", "mode": "SSB" },
+          { "start": 1246000000, "end": 1252000000, "label": "Repeater Outputs", "mode": "FM" },
+          { "start": 1260000000, "end": 1270000000, "label": "Repeater Inputs", "mode": "FM" },
+          { "start": 1296000000, "end": 1300000000, "label": "Experimental / DATV", "mode": "Digital" }
+        ]
+      },
+      {
+        "band": "13 cm Amateur Radio",
+        "start": 2300000000,
+        "end": 2450000000,
+        "subbands": [
+          { "start": 2300000000, "end": 2310000000, "label": "Weak Signal", "mode": "SSB" },
+          { "start": 2310000000, "end": 2330000000, "label": "Digital Modes / ATV", "mode": "Digital" },
+          { "start": 2390000000, "end": 2450000000, "label": "ISM / Shared Use", "mode": "Mixed" }
+        ]
+      },
+      {
+        "band": "9 cm Amateur Radio",
+        "start": 3300000000,
+        "end": 3500000000,
+        "subbands": [
+          { "start": 3300000000, "end": 3320000000, "label": "Weak Signal", "mode": "SSB" },
+          { "start": 3320000000, "end": 3400000000, "label": "ATV / Experimental", "mode": "Digital" },
+          { "start": 3456000000, "end": 3500000000, "label": "Beacon / Mixed", "mode": "Mixed" }
+        ]
+      },
+      {
+        "band": "5 cm Amateur Radio",
+        "start": 5650000000,
+        "end": 5925000000,
+        "subbands": [
+          { "start": 5650000000, "end": 5668000000, "label": "Weak Signal", "mode": "SSB" },
+          { "start": 5668000000, "end": 5725000000, "label": "Telemetry / UAV", "mode": "Digital" },
+          { "start": 5725000000, "end": 5850000000, "label": "FPV Video", "mode": "Digital" },
+          { "start": 5850000000, "end": 5925000000, "label": "ISM / Mixed", "mode": "Mixed" }
+        ]
+      },
+      {
+        "band": "3 cm Amateur Radio",
+        "start": 10000000000,
+        "end": 10500000000,
+        "subbands": [
+          { "start": 10000000000, "end": 10150000000, "label": "Weak Signal / Beacons", "mode": "SSB" },
+          { "start": 10150000000, "end": 10300000000, "label": "Digital / Experimental", "mode": "Digital" },
+          { "start": 10300000000, "end": 10500000000, "label": "Mixed / UAV", "mode": "Mixed" }
+        ]
+      }
   ]
   

--- a/src/data/subbands.json
+++ b/src/data/subbands.json
@@ -1,0 +1,36 @@
+[
+    {
+      "band": "40 m Amateur Radio",
+      "start": 7000000,
+      "end": 7300000,
+      "subbands": [
+        { "start": 7000000, "end": 7030000, "label": "CW", "mode": "CW" },
+        { "start": 7030000, "end": 7040000, "label": "FT8", "mode": "Digital" },
+        { "start": 7040000, "end": 7125000, "label": "Digital Modes", "mode": "Digital" },
+        { "start": 7125000, "end": 7300000, "label": "Phone", "mode": "SSB" }
+      ]
+    },
+    {
+      "band": "20 m Amateur Radio",
+      "start": 14000000,
+      "end": 14350000,
+      "subbands": [
+        { "start": 14000000, "end": 14070000, "label": "CW", "mode": "CW" },
+        { "start": 14074000, "end": 14074000, "label": "FT8", "mode": "Digital" },
+        { "start": 14070000, "end": 14150000, "label": "Digital Modes", "mode": "Digital" },
+        { "start": 14150000, "end": 14350000, "label": "Phone", "mode": "SSB" }
+      ]
+    },
+    {
+      "band": "2 m Amateur Radio",
+      "start": 144000000,
+      "end": 148000000,
+      "subbands": [
+        { "start": 144000000, "end": 144100000, "label": "CW", "mode": "CW" },
+        { "start": 144100000, "end": 144500000, "label": "SSB & Weak Signal", "mode": "SSB" },
+        { "start": 144500000, "end": 145800000, "label": "FM Repeater/Voice", "mode": "FM" },
+        { "start": 145800000, "end": 146000000, "label": "Satellite Uplink", "mode": "Mixed" }
+      ]
+    }
+  ]
+  


### PR DESCRIPTION
Added Interactive Sub-Band Visualizer with Dynamic Labeling and Animations
Summary
This PR introduces a new sub-band visualization feature to the spectrum explorer. It enhances user interaction by allowing users to click on detailed bands and view a breakdown of their internal frequency divisions (CW, SSB, Digital, etc.).

Features
Dynamically rendered sub-band bars based on JSON input (subbands.json)

Responsive SVG visualization with:

Internal frequency ticks

Color-coded sub-bands by mode

Truncated or externally positioned labels based on available space

Animated transitions for bars and labels

Auto-generated dynamic legend for sub-band modes

Scrollable table of sub-band information

Technical Notes
Added intelligent label positioning: labels that don’t fit are automatically placed above the bar with connector lines.

Mode color mapping is extensible and supports compound modes (e.g., "FM/Digital").

Built with D3.js inside the existing React/D3 integration.

 Next Steps / Ideas
Consider making the sub-band SVG a reusable component.

Add hover interactions for sub-band mode explanations or tooltips.

Allow toggling sub-band visibility on the main canvas.